### PR TITLE
Add NugetClearLocalPackagesFolder task

### DIFF
--- a/src/main/groovy/com/ullink/NuGetPlugin.groovy
+++ b/src/main/groovy/com/ullink/NuGetPlugin.groovy
@@ -30,6 +30,15 @@ class NuGetPlugin implements Plugin<Project> {
         project.task('nugetSources', type: NuGetSources) {
             description = 'Adds, removes, enables, disables and lists nuget sources (feeds).'
         }
+
+        def nugetCleanPackagesFolderTask = project.tasks.register('nugetCleanPackagesFolder', NugetClearLocalPackagesFolder)
+                {
+                    description 'Removes local nuget packages folder'
+                }
+
+        project.tasks.named('clean'){
+            dependsOn nugetCleanPackagesFolderTask
+        }
     }
 }
 

--- a/src/main/groovy/com/ullink/NugetClearLocalPackagesFolder.groovy
+++ b/src/main/groovy/com/ullink/NugetClearLocalPackagesFolder.groovy
@@ -1,0 +1,12 @@
+package com.ullink
+
+import org.gradle.api.tasks.Delete
+
+class NugetClearLocalPackagesFolder extends Delete {
+
+    NugetClearLocalPackagesFolder() {
+        def packageFolder = project.file('packages')
+        setDelete(packageFolder)
+        outputs.upToDateWhen { !packageFolder.exists() }
+    }
+}

--- a/src/test/groovy/com/ullink/NuGetSpecTest.groovy
+++ b/src/test/groovy/com/ullink/NuGetSpecTest.groovy
@@ -577,7 +577,7 @@ class NuGetSpecTest {
                             <version>2.1</version>
                             <description>fooDescription</description>
                             <dependencies>
-                                <dependency id="Microsoft.AspNetCore.Mvc.Abstractions" version="1.1.2"/>
+                                <dependency id="Microsoft.AspNetCore.Mvc.Abstractions" version="1.1.3"/>
                                 <dependency id="Microsoft.AspNetCore.Mvc.Core" version="1.1.2"/>
                                 <dependency id="Microsoft.Extensions.Caching.Abstractions" version="1.1.1"/>
                                 <dependency id="Microsoft.Extensions.Configuration.Binder" version="1.1.1"/>

--- a/src/test/groovy/com/ullink/packageparser/PackageReferenceParserSpec.groovy
+++ b/src/test/groovy/com/ullink/packageparser/PackageReferenceParserSpec.groovy
@@ -34,7 +34,7 @@ class PackageReferenceParserSpec extends Specification {
             }
         }
         writer.toString() == '''<dependencies>
-  <dependency id='Microsoft.AspNetCore.Mvc.Abstractions' version='1.1.2' />
+  <dependency id='Microsoft.AspNetCore.Mvc.Abstractions' version='1.1.3' />
   <dependency id='Microsoft.AspNetCore.Mvc.Core' version='1.1.2' />
   <dependency id='Microsoft.Extensions.Caching.Abstractions' version='1.1.1' />
   <dependency id='Microsoft.Extensions.Configuration.Binder' version='1.1.1' />


### PR DESCRIPTION
Task deletes the local "packages" folder created by nuget.
Task is automatically executed when clean is executed, to ensure proper
cleanup of the working folders.

Also had to update 2 test as they were failing

**Reason**
This is rather a workaround for NugetInstall task not retrieving files sometimes.
Running 
`gradlew clean`
 will not delete the "packages" folder.
So, on some instances when running 
`gradle clean <some nuget install task>`
 it will not get the nuget package as it seems like package is already