### PR TITLE
Fix issue #93.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,9 @@ dependencies {
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
 }
 
+repositories {
+  mavenCentral()
+}
 
 pluginBundle {
     website = 'https://github.com/Itiviti/gradle-nuget-plugin'

--- a/src/main/groovy/com/ullink/BaseNuGet.groovy
+++ b/src/main/groovy/com/ullink/BaseNuGet.groovy
@@ -62,6 +62,7 @@ class BaseNuGet extends Exec {
 
     private File getNugetExeLocalPath() {
         File localNuget
+        String nugetExePath = project.extensions.nuget.nugetExePath
 
         if (nugetExePath != null && !nugetExePath.empty && !nugetExePath.startsWith("http")) {
             localNuget = new File(nugetExePath)
@@ -95,6 +96,8 @@ class BaseNuGet extends Exec {
     }
 
     private String getNugetDownloadLink() {
+        String nugetExePath = project.extensions.nuget.nugetExePath
+
         if (nugetExePath != null && !nugetExePath.empty && nugetExePath.startsWith("http")) {
             project.logger.debug("Nuget url path is resolved from property 'nugetExePath'")
 

--- a/src/main/groovy/com/ullink/NuGetExtension.groovy
+++ b/src/main/groovy/com/ullink/NuGetExtension.groovy
@@ -2,4 +2,5 @@ package com.ullink
 
 class NuGetExtension {
     String version = '5.5.0'
+    String nugetExePath = null
 }


### PR DESCRIPTION
I guess this SHOULD fix issue #93. However, I couldn't verify it because the build fails with
```
% ./gradlew build
> Task :compileGroovy FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileGroovy'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Cannot resolve external dependency commons-io:commons-io:2.5 because no repositories are defined.
     Required by:
         project :
```